### PR TITLE
Add a link to the godoc page in "How it works" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ This library is made up of two parts :
 
 ## How it works
 
-Check the godoc, there are many examples provided.
+Check [the godoc](http://godoc.org/github.com/antham/envh), there are many examples provided.


### PR DESCRIPTION
While you still could click the godoc badge at the top of the README, I think it's more convenient to have a link in a place that tells you to go there and read.